### PR TITLE
A missing context in the demo causes the error

### DIFF
--- a/example/lib/advanced_tabs_demo.dart
+++ b/example/lib/advanced_tabs_demo.dart
@@ -15,40 +15,49 @@ class AdvancedTabsDemo extends StatelessWidget {
             routes: {
               [AppPaths.tabsCategory]: PathStack(
                 // Main scaffold is wrapped here
-                scaffoldBuilder: (_, stack) => MainScaffold(
+                scaffoldBuilder: (context, stack) => SafeArea(
+                    child: MainScaffold(
                   child: stack,
                   currentPath: NavStack.of(context).path,
                   // Goto /compose when this is pressed
                   onComposePressed: _handleComposePressed,
-                ),
-                transitionBuilder: (_, stack, animation) => FadeTransition(opacity: animation, child: stack),
+                )),
+                transitionBuilder: (_, stack, animation) =>
+                    FadeTransition(opacity: animation, child: stack),
                 routes: {
                   // Home
                   [HomePage.path]: HomePage("").buildStackRoute(),
                   // Settings
                   [AppPaths.settings]: PathStack(
                     // Settings scaffold is wrapped here
-                    scaffoldBuilder: (_, child) => SettingsScaffold(child: child),
+                    scaffoldBuilder: (_, child) =>
+                        SettingsScaffold(child: child),
                     routes: {
-                      [ProfileSettings.path]: ProfileSettings("").buildStackRoute(),
+                      [ProfileSettings.path]:
+                          ProfileSettings("").buildStackRoute(),
                       [AlertSettings.path]: AlertSettings("").buildStackRoute(),
-                      [BillingSettings.path]: BillingSettings("").buildStackRoute(maintainState: false),
+                      [BillingSettings.path]: BillingSettings("")
+                          .buildStackRoute(maintainState: false),
                     },
                   ).buildStackRoute(),
                   // Inbox
                   [AppPaths.inbox]: PathStack(
                     scaffoldBuilder: (_, child) => InboxScaffold(child: child),
                     routes: {
-                      [InboxPage.friendsPath]: InboxPage(InboxType.friends).buildStackRoute(),
-                      [InboxPage.unreadPath]: InboxPage(InboxType.unread).buildStackRoute(),
-                      [InboxPage.archivedPath]: InboxPage(InboxType.archived).buildStackRoute(),
+                      [InboxPage.friendsPath]:
+                          InboxPage(InboxType.friends).buildStackRoute(),
+                      [InboxPage.unreadPath]:
+                          InboxPage(InboxType.unread).buildStackRoute(),
+                      [InboxPage.archivedPath]:
+                          InboxPage(InboxType.archived).buildStackRoute(),
                     },
                   ).buildStackRoute(),
                 },
               ).buildStackRoute(),
 
               /// Non stateful full-screen route
-              [ComposePage.path]: ComposePage().buildStackRoute(maintainState: false),
+              [ComposePage.path]:
+                  ComposePage().buildStackRoute(maintainState: false),
 
               /// Inject itemId param into detailsView
               [DetailsPage.path + ":id"]: StackRouteBuilder(

--- a/example/lib/advanced_tabs_demo.dart
+++ b/example/lib/advanced_tabs_demo.dart
@@ -15,13 +15,12 @@ class AdvancedTabsDemo extends StatelessWidget {
             routes: {
               [AppPaths.tabsCategory]: PathStack(
                 // Main scaffold is wrapped here
-                scaffoldBuilder: (context, stack) => SafeArea(
-                    child: MainScaffold(
+                scaffoldBuilder: (context, stack) => MainScaffold(
                   child: stack,
                   currentPath: NavStack.of(context).path,
                   // Goto /compose when this is pressed
                   onComposePressed: _handleComposePressed,
-                )),
+                ),
                 transitionBuilder: (_, stack, animation) =>
                     FadeTransition(opacity: animation, child: stack),
                 routes: {

--- a/example/lib/advanced_tabs_demo_pages.dart
+++ b/example/lib/advanced_tabs_demo_pages.dart
@@ -43,7 +43,8 @@ class _SomeStatefulPageState extends State<SomeStatefulPage> {
     if (items == null) return Center(child: CircularProgressIndicator());
     // Filter Items
     final filteredItems = List.from(items!)
-      ..removeWhere((name) => name.toLowerCase().contains(_filter.toLowerCase()) == false);
+      ..removeWhere((name) =>
+          name.toLowerCase().contains(_filter.toLowerCase()) == false);
     return Column(
       children: [
         Row(
@@ -72,14 +73,16 @@ class _SomeStatefulPageState extends State<SomeStatefulPage> {
                     child: Container(
                       width: double.infinity,
                       padding: const EdgeInsets.all(8.0),
-                      color: (index % 2 == 0 ? Colors.grey : Colors.white).withOpacity(.1),
+                      color: (index % 2 == 0 ? Colors.grey : Colors.white)
+                          .withOpacity(.1),
                       child: Row(
                         children: [
                           SizedBox(
                               width: 100,
                               height: 100,
                               child: CachedNetworkImage(
-                                  imageUrl: "https://source.unsplash.com/random/50x50?id=${widget.title}$index")),
+                                  imageUrl:
+                                      "https://source.unsplash.com/random/50x50?id=${widget.title}$index")),
                           Text(filteredItems[index]),
                         ],
                       ),
@@ -134,7 +137,8 @@ class ComposePage extends StatefulWidget {
 class _ComposePageState extends State<ComposePage> {
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    return SafeArea(
+        child: Padding(
       padding: const EdgeInsets.all(8.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -147,13 +151,15 @@ class _ComposePageState extends State<ComposePage> {
               Text("New Message:", style: TextStyle(fontSize: 32)),
               TextField(
                   maxLines: 10,
-                  decoration: InputDecoration(border: OutlineInputBorder(borderSide: BorderSide(color: Colors.black)))),
+                  decoration: InputDecoration(
+                      border: OutlineInputBorder(
+                          borderSide: BorderSide(color: Colors.black)))),
               Spacer(flex: 3),
             ],
           ))
         ],
       ),
-    );
+    ));
   }
 }
 
@@ -174,7 +180,8 @@ class _DetailsPageState extends State<DetailsPage> {
   List<String> items = List.generate(100, (index) => "$index");
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    return SafeArea(
+        child: Padding(
       padding: const EdgeInsets.all(20),
       child: Column(
         children: [
@@ -193,7 +200,7 @@ class _DetailsPageState extends State<DetailsPage> {
           ),
         ],
       ),
-    );
+    ));
   }
 
   String getId(int dir) {

--- a/example/lib/advanced_tabs_demo_scaffold.dart
+++ b/example/lib/advanced_tabs_demo_scaffold.dart
@@ -11,7 +11,11 @@ class MainScaffold extends StatefulWidget {
   final Widget child;
   final String currentPath;
   final VoidCallback onComposePressed;
-  const MainScaffold({Key? key, required this.child, required this.currentPath, required this.onComposePressed})
+  const MainScaffold(
+      {Key? key,
+      required this.child,
+      required this.currentPath,
+      required this.onComposePressed})
       : super(key: key);
 
   @override
@@ -21,7 +25,8 @@ class MainScaffold extends StatefulWidget {
 class _MainScaffoldState extends State<MainScaffold> {
   @override
   Widget build(BuildContext context) {
-    return Stack(
+    return SafeArea(
+        child: Stack(
       children: [
         BackBtn(),
         Padding(
@@ -35,7 +40,8 @@ class _MainScaffoldState extends State<MainScaffold> {
                   color: Colors.grey.shade200,
                   width: double.infinity,
                   child: Text("https://myflutterapp/${widget.currentPath}",
-                      style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+                      style:
+                          TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
                 ),
               ],
               Expanded(child: widget.child),
@@ -43,12 +49,16 @@ class _MainScaffoldState extends State<MainScaffold> {
                 NavBtn("home", target: AppPaths.tabsCategory + HomePage.path),
                 NavBtn("settings",
                     // TODO: Would be nice to remember the previous tab position. best option is to hoist state?
-                    target: AppPaths.tabsCategory + AppPaths.settings + ProfileSettings.path,
+                    target: AppPaths.tabsCategory +
+                        AppPaths.settings +
+                        ProfileSettings.path,
                     // Using an alias, so the btn knows to highlight on this portion of the path
                     selectionAlias: AppPaths.tabsCategory + AppPaths.settings),
                 NavBtn("inbox",
                     // TODO: Would be nice to remember the previous tab position. best option is to hoist state?
-                    target: AppPaths.tabsCategory + AppPaths.inbox + InboxPage.friendsPath,
+                    target: AppPaths.tabsCategory +
+                        AppPaths.inbox +
+                        InboxPage.friendsPath,
                     // Using an alias, so the btn knows to highlight on this portion of the path
                     selectionAlias: AppPaths.tabsCategory + AppPaths.inbox),
               ]),
@@ -58,10 +68,11 @@ class _MainScaffoldState extends State<MainScaffold> {
         Positioned(
           bottom: 80,
           right: 12,
-          child: FloatingActionButton(onPressed: widget.onComposePressed, child: Icon(Icons.add)),
+          child: FloatingActionButton(
+              onPressed: widget.onComposePressed, child: Icon(Icons.add)),
         )
       ],
-    );
+    ));
   }
 }
 
@@ -82,9 +93,15 @@ class _SettingsScaffoldState extends State<SettingsScaffold> {
       child: Column(children: [
         Row(
           children: [
-            NavBtn("profile", target: "${AppPaths.tabsCategory}${AppPaths.settings}${ProfileSettings.path}"),
-            NavBtn("alerts", target: "${AppPaths.tabsCategory}${AppPaths.settings}${AlertSettings.path}"),
-            NavBtn("Billing", target: "${AppPaths.tabsCategory}${AppPaths.settings}${BillingSettings.path}"),
+            NavBtn("profile",
+                target:
+                    "${AppPaths.tabsCategory}${AppPaths.settings}${ProfileSettings.path}"),
+            NavBtn("alerts",
+                target:
+                    "${AppPaths.tabsCategory}${AppPaths.settings}${AlertSettings.path}"),
+            NavBtn("Billing",
+                target:
+                    "${AppPaths.tabsCategory}${AppPaths.settings}${BillingSettings.path}"),
           ],
         ),
         Expanded(child: widget.child),
@@ -111,9 +128,15 @@ class _InboxScaffoldState extends State<InboxScaffold> {
         Row(
           children: [
             // TODO: Create some sort of AppPath.builder method? Or many methods???
-            NavBtn("friends", target: "${AppPaths.tabsCategory}${AppPaths.inbox}${InboxPage.friendsPath}"),
-            NavBtn("unread", target: "${AppPaths.tabsCategory}${AppPaths.inbox}${InboxPage.unreadPath}"),
-            NavBtn("archived", target: "${AppPaths.tabsCategory}${AppPaths.inbox}${InboxPage.archivedPath}"),
+            NavBtn("friends",
+                target:
+                    "${AppPaths.tabsCategory}${AppPaths.inbox}${InboxPage.friendsPath}"),
+            NavBtn("unread",
+                target:
+                    "${AppPaths.tabsCategory}${AppPaths.inbox}${InboxPage.unreadPath}"),
+            NavBtn("archived",
+                target:
+                    "${AppPaths.tabsCategory}${AppPaths.inbox}${InboxPage.archivedPath}"),
           ],
         ),
         Expanded(child: widget.child),


### PR DESCRIPTION
Tried to open the demo, but got this
```
═══════════════════════╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY╞═══════════════════════
The following _CastError was thrown building PathStack(dirty, dependencies:
[_InheritedPathStack],
state: PathStackState#e449a(ticker active)):
type 'Null' is not a subtype of type '_InheritedNavStackController' in type cast

The relevant error-causing widget was:
  PathStack
  ./flutter_nav_stack/example/lib/advanced_tabs_demo.dart:16:40

```

fixed this stuff and wrapped in a SafeArea widget for better experience
